### PR TITLE
feat(server:main)!: remove job managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Mechanic Job for Qbox Framework
 ![On Duty/Off Duty](https://i.imgur.com/CM34EsL.png)
 
 ## Features
+- /setmechanic - Sets someone mechanic
+- /firemechanic - Fires a mechanic worker
 - On Duty/Off Duty
 - Placing vehicles to platform for repairing it part by part.
 - Towtruck, Blista, Minivan, Flatbed for workers.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # qb-mechanicjob
-Mechanic Job for QB-Core Framework :mechanic:
-
-## Dependencies
-- [qb-core](https://github.com/qbcore-framework/qb-core)
-- [qb-inventory](https://github.com/qbcore-framework/qb-inventory) - 
+Mechanic Job for Qbox Framework
 
 ## Screenshots
 ![Platform](https://imgur.com/KzmXIaY.png)
@@ -12,160 +8,16 @@ Mechanic Job for QB-Core Framework :mechanic:
 ![On Duty/Off Duty](https://i.imgur.com/CM34EsL.png)
 
 ## Features
-- /setmechanic - Sets someone mechanic
-- /firemechanic - Fires a mechanic worker
 - On Duty/Off Duty
 - Placing vehicles to platform for repairing it part by part.
 - Towtruck, Blista, Minivan, Flatbed for workers.
 
 ## Installation
 ### Manual
-- Download the script and put it in the `[qb]` directory.
+- Download the script and put it in the `[qbx]` directory.
 - Import `qb-.sql` in your database
 - Add the following code to your server.cfg/resouces.cfg
 ```
-ensure qb-core
-ensure qb-inventory
-ensure qb-mechanicjob
-```
-
-## Configuration
-```
-Config.AttachedVehicle = nil -- Don't touch
-
-Config.AuthorizedIds = { -- Authorized citizens (citizenid)
-    "insertcitizenidhere",
-}
-
-Config.MaxStatusValues = { -- Max health values for parts
-    ["engine"] = 1000.0,
-    ["body"] = 1000.0,
-    ["radiator"] = 100,
-    ["axle"] = 100,
-    ["brakes"] = 100,
-    ["clutch"] = 100,
-    ["fuel"] = 100,
-}
-
-Config.ValuesLabels = { -- Labels of parts (will be shown at platform)
-    ["engine"] = "Motor",
-    ["body"] = "Body",
-    ["radiator"] = "Radiator",
-    ["axle"] = "Drive Shaft",
-    ["brakes"] = "Brakes",
-    ["clutch"] = "Clutch",
-    ["fuel"] = "Fuel Ttank",
-}
-
-Config.RepairCost = {
-    ["body"] = "plastic", -- Material needed to repair the part
-    ["radiator"] = "plastic",
-    ["axle"] = "steel",
-    ["brakes"] = "iron",
-    ["clutch"] = "aluminum",
-    ["fuel"] = "plastic",
-}
-
-Config.RepairCostAmount = { -- Material count needed to repair the part
-    ["engine"] = {
-        item = "metalscrap",
-        costs = 2,
-    },
-    ["body"] = {
-        item = "plastic",
-        costs = 3,
-    },
-    ["radiator"] = {
-        item = "steel",
-        costs = 5,
-    },
-    ["axle"] = {
-        item = "aluminum",
-        costs = 7,
-    },
-    ["brakes"] = {
-        item = "copper",
-        costs = 5,
-    },
-    ["clutch"] = {
-        item = "copper",
-        costs = 6,
-    },
-    ["fuel"] = {
-        item = "plastic",
-        costs = 5,
-    },
-}
-
-Config.Businesses = {
-    "Auto Repair",
-}
-
-Config.Plates = { -- Platforms
-    [1] = {
-        coords = {x = 937.91, y = -970.64, z = 39.49, h = 271.5, r = 1.0},
-        AttachedVehicle = nil,
-    },
-    [2] = {
-        coords = {x = 922.37, y = -979.86, z = 39.49, h = 271.5, r = 1.0}, 
-        AttachedVehicle = nil,
-    },
-    [3] = {
-        coords = {x = 921.54, y = -962.17, z = 39.49, h = 274.5, r = 1.0}, 
-        AttachedVehicle = nil,
-    },
-    [4] = {
-        coords = {x = 949.89, y = -947.75, z = 39.49, h = 90.5, r = 1.0}, 
-        AttachedVehicle = nil,
-    },
-}
-
-Config.Locations = {
-    ["exit"] = {x = 945.13, y = -975.84, z = 39.49, h = 181.5, r = 1.0},
-    ["stash"] = {x = 947.62, y = -972.46, z = 39.49, h = 274.5, r = 1.0}, -- Stash Marker Location
-    ["duty"] = {x = 950.73, y = -968.64, z = 39.5, h = 180.5, r = 1.0}, -- On Duty/Off Duty Marker Location
-    ["vehicle"] = {x = 937.93, y = -990.7, z = 38.42, h = 94.5, r = 1.0},  -- Marker Location for towtruck, flatbed etc.
-}
-
-Config.Vehicles = { -- Available vehicles for workers
-    ["flatbed"] = "Flatbed",
-    ["towtruck"] = "Towtruck",
-    ["minivan"] = "Minivan (Leen Auto)",
-    ["blista"] = "Blista",
-}
-
-Config.MinimalMetersForDamage = { -- Minimum distance player needs to drive in order to vehicle to get damaged
-    [1] = {
-        min = 8000,
-        max = 12000,
-        multiplier = {
-            min = 1,
-            max = 8,
-        }
-    },
-    [2] = {
-        min = 12000,
-        max = 16000,
-        multiplier = {
-            min = 8,
-            max = 16,
-        }
-    },
-    [3] = {
-        min = 12000,
-        max = 16000,
-        multiplier = {
-            min = 16,
-            max = 24,
-        }
-    },
-}
-
-Config.Damages = { -- Part labels which will be damaged
-    ["radiator"] = "Radiator",
-    ["axle"] = "Drive Shaft",
-    ["brakes"] = "Brakes",
-    ["clutch"] = "Clutch",
-    ["fuel"] = "Fuel Tank",
-}
+ensure qbx-core
+ensure qbx-mechanicjob
 ```

--- a/config.lua
+++ b/config.lua
@@ -7,10 +7,6 @@ Config.Targets = {}
 
 Config.AttachedVehicle = nil
 
-Config.AuthorizedIds = {
-    -- "insertcitizenidhere",
-}
-
 Config.MaxStatusValues = {
     ["engine"] = 1000.0,
     ["body"] = 1000.0,

--- a/server/main.lua
+++ b/server/main.lua
@@ -23,18 +23,6 @@ function GetVehicleStatus(plate)
     return retval
 end
 
-function IsAuthorized(CitizenId)
-    local retval = false
-    for _, cid in pairs(Config.AuthorizedIds) do
-        if cid == CitizenId then
-            retval = true
-            break
-        end
-    end
-    return retval
-end
-
-
 -- Callbacks
 
 QBCore.Functions.CreateCallback('qb-vehicletuning:server:GetDrivingDistances', function(_, cb)
@@ -238,57 +226,3 @@ QBCore.Commands.Add("setvehiclestatus", "Set Vehicle Status", {{
     local level = tonumber(args[2])
     TriggerClientEvent("vehiclemod:client:setPartLevel", source, part, level)
 end, "god")
-
-QBCore.Commands.Add("setmechanic", "Give Someone The Mechanic job", {{
-    name = "id",
-    help = "ID Of The Player"
-}}, false, function(source, args)
-    local Player = QBCore.Functions.GetPlayer(source)
-
-    if IsAuthorized(Player.PlayerData.citizenid) then
-        local TargetId = tonumber(args[1])
-        if TargetId ~= nil then
-            local TargetData = QBCore.Functions.GetPlayer(TargetId)
-            if TargetData ~= nil then
-                TargetData.Functions.SetJob("mechanic")
-                TriggerClientEvent('QBCore:Notify', TargetData.PlayerData.source,
-                    "You Were Hired As An Autocare Employee!")
-                TriggerClientEvent('QBCore:Notify', source, "You have (" .. TargetData.PlayerData.charinfo.firstname ..
-                    ") Hired As An Autocare Employee!")
-            end
-        else
-            TriggerClientEvent('QBCore:Notify', source, "You Must Provide A Player ID!")
-        end
-    else
-        TriggerClientEvent('QBCore:Notify', source, "You Cannot Do This!", "error")
-    end
-end)
-
-QBCore.Commands.Add("firemechanic", "Fire A Mechanic", {{
-    name = "id",
-    help = "ID Of The Player"
-}}, false, function(source, args)
-    local Player = QBCore.Functions.GetPlayer(source)
-
-    if IsAuthorized(Player.PlayerData.citizenid) then
-        local TargetId = tonumber(args[1])
-        if TargetId ~= nil then
-            local TargetData = QBCore.Functions.GetPlayer(TargetId)
-            if TargetData ~= nil then
-                if TargetData.PlayerData.job.name == "mechanic" then
-                    TargetData.Functions.SetJob("unemployed")
-                    TriggerClientEvent('QBCore:Notify', TargetData.PlayerData.source,
-                        "You Were Fired As An Autocare Employee!")
-                    TriggerClientEvent('QBCore:Notify', source,
-                        "You have (" .. TargetData.PlayerData.charinfo.firstname .. ") Fired As Autocare Employee!")
-                else
-                    TriggerClientEvent('QBCore:Notify', source, "Youre Not An Employee of Autocare!", "error")
-                end
-            end
-        else
-            TriggerClientEvent('QBCore:Notify', source, "You Must Provide A Player ID!", "error")
-        end
-    else
-        TriggerClientEvent('QBCore:Notify', source, "You Cannot Do This!", "error")
-    end
-end)


### PR DESCRIPTION
## Description

- removed commands for authorized citizenIds in config to hire and fire mechanics. This should be done using qbx-management instead
- also sneaking in some README updates

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
